### PR TITLE
Enable toggling of all items display

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -98,13 +98,13 @@
 
       <h1 slot="header" class="hidden"><code class="main">&lt;vcf-multi-select&gt;</code></h1>
 
-      <vcf-anchor-nav-section name="Example">
+      <vcf-anchor-nav-section name="Default select">
         <demo-snippet>
           <template>
-            <vcf-multi-select></vcf-multi-select>
+            <vcf-multi-select id="defaultSelect"></vcf-multi-select>
             <script>
                   window.addEventListener('WebComponentsReady', function() {
-                    document.querySelector('vcf-multi-select').renderer = function(root) {
+                    document.querySelector('#defaultSelect').renderer = function(root) {
                       // Check if there is a list-box generated with the previous renderer call to update its content instead of recreation
                       if (root.firstChild) {
                         return;
@@ -113,6 +113,33 @@
                       const listBox = window.document.createElement('vaadin-list-box');
                       // append 3 <vaadin-item> elements
                       ['Jose', 'Manolo', 'Pedro'].forEach(function(name) {
+                        const item = window.document.createElement('vaadin-item');
+                        item.textContent = name;
+                        listBox.appendChild(item);
+                      });
+                      // update the content
+                      root.appendChild(listBox);
+                    };
+                  });
+            </script>
+          </template>
+        </demo-snippet>
+      </vcf-anchor-nav-section>
+	  <vcf-anchor-nav-section name="Display-all-selected">
+        <demo-snippet>
+          <template>
+            <vcf-multi-select id="displayAllSelect" display-all-selected></vcf-multi-select>
+            <script>
+                  window.addEventListener('WebComponentsReady', function() {
+                    document.querySelector('#displayAllSelect').renderer = function(root) {
+                      // Check if there is a list-box generated with the previous renderer call to update its content instead of recreation
+                      if (root.firstChild) {
+                        return;
+                      }
+                      // create the <vaadin-list-box>
+                      const listBox = window.document.createElement('vaadin-list-box');
+                      // append 4 <vaadin-item> elements
+                      ['Jose', 'Manolo', 'Pedro', 'Luis'].forEach(function(name) {
                         const item = window.document.createElement('vaadin-item');
                         item.textContent = name;
                         listBox.appendChild(item);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin-component-factory/vcf-multi-select",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A select element (similar to vaadin-select) that supports selecting multiple items",
   "main": "src/vcf-multi-select.js",
   "author": "Vaadin Ltd",

--- a/src/vcf-multi-select.js
+++ b/src/vcf-multi-select.js
@@ -513,6 +513,7 @@ class VcfMultiSelectElement extends
 
   setExtraItemsCountText(singularString, pluralString){
     this.extraItemsCountText = [singularString, pluralString];
+    this._updateValueSlot();
   }
 
   getExtraItemsCountText(){


### PR DESCRIPTION
By default, only the first selected value is displayed in the field, with the number of additionally selected values (N) is indicated as "(+N other(s))".

This PR adds the possibility of changing this behavior by setting the displayAllSelected property to true, in which case all selected items will be displayed, comma-separated, with ellipsis if more items are present than fits the component.